### PR TITLE
16 graph model import

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ class GraphModel {
     testInsert(dataDirectory, wpSepThresh, tle, refVertex)$ bool
     testFilterEdges(edges, maxWeight, refEdges)$ bool
     testSearch(dataDirectory, wpSepThresh, observations, pos, radius)$ unordered_set<int>
+    testImport(dataDirectory, wpSepThresh)$ 
 }
 class Vertex {
     index int
@@ -183,6 +184,7 @@ class Edge {
 - `testInsert()` - Tests inserting a two line element into the Graph and compares the Vertex that was generated to a reference vertex
 - `testFilterEdges()` - Tests the `_filterByWeight()` function which filters a vector of edges to return the vertices index whose weight (distance) is below the max weight
 - `testSearch()` - Tests the `search()` function which searches for observations that occurred within range of a position during the observation period
+- `testImport()` - Tests the `import()` function to check if the process throws any errors
 
 ## LinearModel Class
 ***

--- a/lib/libsgp4/Tle.cc
+++ b/lib/libsgp4/Tle.cc
@@ -93,6 +93,16 @@ void Tle::Initialize()
     unsigned int sat_number_1;
     unsigned int sat_number_2;
 
+	// Check to see if either string for the sat number has a 'T' pretended at the beginning
+	std::string satString1, satString2;
+	satString1 = line_one_.substr(TLE1_COL_NORADNUM,TLE1_LEN_NORADNUM);
+	satString2 = line_two_.substr(TLE2_COL_NORADNUM,TLE2_LEN_NORADNUM);
+
+	if (satString1[0] == 'T')
+		satString1.substr(1);
+	if (satString2[0] == 'T')
+		satString2.substr(1);
+
     ExtractInteger(line_one_.substr(TLE1_COL_NORADNUM,
                 TLE1_LEN_NORADNUM), sat_number_1);
     ExtractInteger(line_two_.substr(TLE2_COL_NORADNUM,

--- a/lib/libsgp4/Tle.cc
+++ b/lib/libsgp4/Tle.cc
@@ -99,9 +99,9 @@ void Tle::Initialize()
 	satString2 = line_two_.substr(TLE2_COL_NORADNUM,TLE2_LEN_NORADNUM);
 
 	if (satString1[0] == 'T')
-		satString1.substr(1);
+		satString1 = satString1.substr(1);
 	if (satString2[0] == 'T')
-		satString2.substr(1);
+		satString2 = satString2.substr(1);
 
     ExtractInteger(satString1, sat_number_1);
     ExtractInteger(satString2, sat_number_2);

--- a/lib/libsgp4/Tle.cc
+++ b/lib/libsgp4/Tle.cc
@@ -103,10 +103,8 @@ void Tle::Initialize()
 	if (satString2[0] == 'T')
 		satString2.substr(1);
 
-    ExtractInteger(line_one_.substr(TLE1_COL_NORADNUM,
-                TLE1_LEN_NORADNUM), sat_number_1);
-    ExtractInteger(line_two_.substr(TLE2_COL_NORADNUM,
-                TLE2_LEN_NORADNUM), sat_number_2);
+    ExtractInteger(satString1, sat_number_1);
+    ExtractInteger(satString2, sat_number_2);
 
     if (sat_number_1 != sat_number_2)
     {

--- a/src/GraphModel.cpp
+++ b/src/GraphModel.cpp
@@ -50,7 +50,21 @@ GraphModel::GraphModel(string &directory, const double &sepThresh) : _dataDirect
  */
 void GraphModel::import()
 {
-	// TODO: Implement the import() function for the GraphModel class
+	// Get the .tle files at the _dataDirectory
+	auto filePaths = TLEParser::getTLEFiles(_dataDirectory);
+
+	// For each file, process the files and insert the TLE entries into the model
+	vector<Tle> observations;
+	for (const auto &filePath : filePaths)
+	{
+		TLEParser::parseTLEFile(filePath, observations, false);
+	}
+
+	// For each observation, insert it into the model
+	for (const auto &tle : observations)
+	{
+		insert(tle);
+	}
 }
 
 /**
@@ -216,6 +230,20 @@ unordered_set<int> GraphModel::testSearch(string &dataDirectory, const double &w
 
 	// Compare the search result to the refSatCatNums
 	return result;
+}
+
+/**
+ * Tests the import() function
+ * @param dataDirectory the path to the data source for the GraphModel
+ * @param wpSepThresh the threshold that causes a new waypoint to be generated
+ */
+void GraphModel::testImport(string &dataDirectory, const double &wpSepThresh)
+{
+	// Create an instance of the GraphModel class
+	GraphModel graph(dataDirectory, wpSepThresh);
+
+	// Perform the import process
+	graph.import();
 }
 
 

--- a/src/GraphModel.h
+++ b/src/GraphModel.h
@@ -44,6 +44,7 @@ public:
 	static bool testInsert(string &dataDirectory, const double &wpSepThresh, const Tle &tle, const Vertex &refVertex);
 	static bool testFilterEdges(const vector<Edge> &edges, const double &maxWeight, const vector<Edge> &refEdges);
 	static unordered_set<int> testSearch(string &dataDirectory, const double &wpSepThresh, const vector<Tle> &observations, const CoordGeodetic &pos, const double &radius);
+	static void testImport(string &dataDirectory, const double &wpSepThresh);
 
 private:
 	/* ========== PRIVATE MEMBER VARIABLES ========== */

--- a/src/SatelliteCoverageTracker.cpp
+++ b/src/SatelliteCoverageTracker.cpp
@@ -5,24 +5,7 @@ using namespace std;
 
 /* =============== PUBLIC METHODS =============== */
 /* ---------------------------------------------- */
-void SatelliteCoverageTracker::importDataFromLocalFile(const string& inputFilePath) {
-    TLEParser parser;
-    const string outputPath = "data/tle_latest.txt";
 
-    //--- Retrieves TLE data from file ---------//
-    bool success = parser.fetchTLEDataFromFile(inputFilePath, outputPath);
-    if (success) {
-        string successful_statement;
-        successful_statement = "Successfully retrieved TLE data.";
-        cout << successful_statement << endl;
-        parser.parseTLE(outputPath);
-    }
-    else {
-        string unsuccessful_statement;
-        unsuccessful_statement = "Unsuccessfully retrieved TLE data";
-        cerr << unsuccessful_statement << endl;
-    }
-}
 
 /* ========== CONSTRUCTORS/DESTRUCTORS ========== */
 SatelliteCoverageTracker::SatelliteCoverageTracker(const string& pathToData, const DateTime& dateTime, const CoordGeodetic& location)

--- a/src/SatelliteCoverageTracker.h
+++ b/src/SatelliteCoverageTracker.h
@@ -7,8 +7,7 @@ using namespace libsgp4;
 
 
 struct SatelliteCoverageTracker {
-public: 
-	void importDataFromLocalFile(const std::string& inputFilePath);
+public:
 	/* ========== CONSTRUCTORS/DESTRUCTORS ========== */
 	SatelliteCoverageTracker(const string &pathToData, const DateTime &dateTime, const CoordGeodetic &location);
 

--- a/src/TLEParser.cpp
+++ b/src/TLEParser.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 
 /* =========== PUBLIC STATIC METHODS ============ */
-Tle TLEParser::parse(const string &tleString)
+Tle TLEParser::parse(string &tleString)
 {
 	// Split the string passed to the function into three lines
 	vector<string> lines(3);
@@ -15,6 +15,10 @@ Tle TLEParser::parse(const string &tleString)
 	istringstream stream(tleString);
 	while (getline(stream, line))
 	{
+		// If there is a carriage return at the end of the line, remove it
+		if (line.back() == '\r')
+			line.pop_back();
+
 		lines.emplace_back(line);
 	}
 
@@ -24,12 +28,26 @@ Tle TLEParser::parse(const string &tleString)
 	else
 		return _parse(lines[0], lines[1]);
 }
-Tle TLEParser::parse(const string &line1, const string &line2)
+Tle TLEParser::parse(string &line1, string &line2)
 {
+	// Check line 1 and line 2 to make sure there is not a carriage return character at the end of the string
+	if (line1.back() == '\r')
+		line1.pop_back();
+
+	if (line2.back() == '\r')
+		line2.pop_back();
+
 	return _parse(line1, line2);
 }
-Tle TLEParser::parse(const string &line1, const string &line2, const string &line3)
+Tle TLEParser::parse(string &line1, string &line2, string &line3)
 {
+	// Check line 2 and line 3 to make sure there is not a carriage return character at the end of the string
+	if (line2.back() == '\r')
+		line1.pop_back();
+
+	if (line3.back() == '\r')
+		line2.pop_back();
+
 	return _parse(line1, line2, line3);
 }
 
@@ -39,13 +57,13 @@ CoordGeodetic TLEParser::getCoordGeodetic(const Tle &tle)
 
 	return sgp4.FindPosition(tle.Epoch()).ToGeodetic();
 }
-CoordGeodetic TLEParser::getCoordGeodetic(const string &line1, const string &line2, const string &line3)
+CoordGeodetic TLEParser::getCoordGeodetic(string &line1, string &line2, string &line3)
 {
 	auto tle = TLEParser::parse(line1, line2, line3);
 
 	return TLEParser::getCoordGeodetic(tle);
 }
-CoordGeodetic TLEParser::getCoordGeodetic(const string &line1, const string &line2)
+CoordGeodetic TLEParser::getCoordGeodetic(string &line1, string &line2)
 {
 	auto tle = TLEParser::parse(line1, line2);
 
@@ -57,7 +75,7 @@ CoordGeodetic TLEParser::getCoordGeodetic(const string &line1, const string &lin
  * @param directoryPath the directory to search for files
  * @return a vector of strings representing the paths to the TLE files in that directory
  */
-vector<string> getTLEFiles(const string& directoryPath) {
+vector<string> TLEParser::getTLEFiles(const string& directoryPath) {
 	vector<string> tleFiles;
 
 	for (const auto& entry : filesystem::directory_iterator(directoryPath))
@@ -106,14 +124,14 @@ void TLEParser::parseTLEFile(const string& tlePath, vector<Tle> &observations, b
 	{
 		while (getline(inFile, tleLine1)) {
 			if (getline(inFile, tleLine2) && getline(inFile, tleLine3))
-				observations.emplace_back(_parse(tleLine1, tleLine2, tleLine3));
+				observations.emplace_back(parse(tleLine1, tleLine2, tleLine3));
 		}
 	}
 	else
 	{
 		while (getline(inFile, tleLine1)) {
 			if (getline(inFile, tleLine2))
-				observations.emplace_back(_parse(tleLine1, tleLine2));
+				observations.emplace_back(parse(tleLine1, tleLine2));
 		}
 	}
 

--- a/src/TLEParser.h
+++ b/src/TLEParser.h
@@ -15,13 +15,13 @@ private:
 
 public:
 	/* ========== PUBLIC STATIC METHODS ========== */
-	static Tle parse(const string &tleString);
-	static Tle parse(const string &line1, const string &line2);
-	static Tle parse(const string &line1, const string &line2, const string &line3);
+	static Tle parse(string &tleString);
+	static Tle parse(string &line1, string &line2);
+	static Tle parse(string &line1, string &line2, string &line3);
 
 	static CoordGeodetic getCoordGeodetic(const Tle &tle);
-	static CoordGeodetic getCoordGeodetic(const string &line1, const string &line2, const string &line3);
-	static CoordGeodetic getCoordGeodetic(const string &line1, const string &line2);
+	static CoordGeodetic getCoordGeodetic(string &line1, string &line2, string &line3);
+	static CoordGeodetic getCoordGeodetic(string &line1, string &line2);
 
 	static vector<string> getTLEFiles(const string &directoryPath);
 	static vector<Tle> parseTLEFile(const string& tlePath, bool isThreeLine);

--- a/tests/Graph-tests.cpp
+++ b/tests/Graph-tests.cpp
@@ -9,7 +9,7 @@ using namespace libsgp4;
 
 TEST_CASE("Check for a waypoint for a new graph", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 1;
+	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 
 	CoordGeodetic position(0.0, 0.0, 0.0, false);
@@ -20,7 +20,7 @@ TEST_CASE("Check for a waypoint for a new graph", "[GraphModel][Waypoint][Search
 
 TEST_CASE("Check for a waypoint when one already exists", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 1;
+	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 
 	vector<CoordGeodetic> positions = {
@@ -40,7 +40,7 @@ TEST_CASE("Check for a waypoint when one already exists", "[GraphModel][Waypoint
 
 TEST_CASE("Get the waypoint nearest to a position", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 0.9;
+	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 	vector<CoordGeodetic> wpPositions = {
 			{ 0, 0, 0, true },
@@ -70,7 +70,7 @@ TEST_CASE("Insert an observation", "[GraphModel][Insert]")
 
 	// Parameters for test
 	string dataDirectory = "../data";
-	double wpSepThreshDeg = 0.9;
+	double wpSepThreshDeg = 2000; // kilometers
 	const GraphModel::Vertex vertex = { 0, false, { 0.88899156265206469, -0.073645485312217928, 426.37173319160553, true }};
 
 	REQUIRE(GraphModel::testInsert(dataDirectory, wpSepThreshDeg, tle, vertex));
@@ -106,8 +106,8 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 {
 	// Parameters for test
 	string dataDirectory = "../data";
-	string pathToTestFile = "../data/test_01.tle";
-	double wpSepThreshDeg = 0.9;
+	string pathToTestFile = "../data/test_files/test_01.tle";
+	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 0, 158.925, 561.694, false };
 	double radius = 10; // units: km
 	unordered_set<int> refCatNums = { 12 };
@@ -154,8 +154,8 @@ TEST_CASE("Search for observations relative to position and within a range for 5
 {
 	// Parameters for test
 	string dataDirectory = "../data";
-	string pathToTestFile = "../data/test_02.tle";
-	double wpSepThreshDeg = 0.9;
+	string pathToTestFile = "../data/test_files/test_02.tle";
+	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 0, 153, 0, false };
 	double radius = 700; // units: km
 	unordered_set<int> refCatNums = { 12, 29, 51, 85, 115 };
@@ -202,8 +202,8 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 {
 	// Parameters for test
 	string dataDirectory = "../data";
-	string pathToTestFile = "../data/test_03.tle";
-	double wpSepThreshDeg = 1;
+	string pathToTestFile = "../data/test_files/test_03.tle";
+	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 29.649294, -82.339383, 0, false }; // Lat, Long of Tigert hall
 	double radius = 1000; // units: km
 	unordered_set<int> refCatNums = { 340, 414, 549, 745, 561, 446, 657, 268, 406, 544, 659, 648, 672, 660, 405, 704, 224, 753 };
@@ -243,4 +243,13 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 		INFO("Test file at path '" + pathToTestFile + "' could not be opened!");
 		REQUIRE(false);
 	}
+}
+
+TEST_CASE("Import all the TLE data in the data directory", "[GraphModel][Import]")
+{
+	string dataDirectory = "../data";
+	double wpSepThreshDeg = 2000; // kilometers
+
+	// Perform the import
+	REQUIRE_NOTHROW(GraphModel::testImport(dataDirectory, wpSepThreshDeg));
 }

--- a/tests/TLEParser-tests.cpp
+++ b/tests/TLEParser-tests.cpp
@@ -5,9 +5,9 @@
 TEST_CASE("TLEParser parse() single string input", "[TLEParser][Method]")
 {
 	// Construct two strings that represent the two lines of the element set
-	const string name = "ISS (ZARYA)";
-	const string lineOne = "1 25544U 98067A   24332.90817323  .00022340  00000-0  39860-3 0  9997";
-	const string lineTwo = "2 25544  51.6388 224.2748 0006855 275.7348  84.2859 15.49960541483940";
+	string name = "ISS (ZARYA)";
+	string lineOne = "1 25544U 98067A   24332.90817323  .00022340  00000-0  39860-3 0  9997";
+	string lineTwo = "2 25544  51.6388 224.2748 0006855 275.7348  84.2859 15.49960541483940";
 
 	// Required position
 	CoordGeodetic reqPos(-2.5254170250617857E-7, -2.9664422763591514, 417.12408784880648, true);
@@ -16,4 +16,12 @@ TEST_CASE("TLEParser parse() single string input", "[TLEParser][Method]")
 	INFO(position.ToString());
 
 	REQUIRE(position == reqPos);
+}
+
+TEST_CASE("TLEParser parseTLEFile() for file with entries using a temporary designation", "[TLEParser][Static][Method]")
+{
+	string filePath = "../data/test_files/test_04.tle";
+	vector<Tle> observations;
+
+	REQUIRE_NOTHROW(TLEParser::parseTLEFile(filePath, observations, false));
 }


### PR DESCRIPTION
- Fixes bugs in Tle class causing errors for new observations or observations with temporary designations
- Adds overloads to the parseTLEFile() function and adds tests for that function
- Removes importDataFromLocalFile() from SatelliteCoverageTracker class
- Implements the import() function for the GraphModel class