### PR TITLE
refactor: removes the waypoint threshold parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ A class that represents Tle observations in a Graph data structure and supports 
 ```mermaid
 classDiagram
 class GraphModel {
-    GraphModel(directory, sepThresh)
+    GraphModel(directory)
     import()
     insert(tle)
     search(position, radius) unordered_set<int>
@@ -169,7 +169,7 @@ class Edge {
 - `Edge` - A public struct that represents a connection between vertices in the graph
 
 ### Construction
-- `GraphModel(directory, sepThresh)` - constructor that takes in a path to the data directory and a waypoint separation threshold
+- `GraphModel(directory)` - constructor that takes in a path to the data directory
 
 ### Mutators
 - `import()` - Performs the import process for all .tle files found in the data directory

--- a/src/GraphModel.cpp
+++ b/src/GraphModel.cpp
@@ -42,7 +42,7 @@ bool GraphModel::Edge::operator==(const Edge &rhs) const
 /* ============== GraphModel CLASS ============== */
 /* ---------------------------------------------- */
 /* ========== CONSTRUCTORS/DESTRUCTORS ========== */
-GraphModel::GraphModel(string &directory, const double &sepThresh) : _dataDirectory(directory), _wpSeparation(sepThresh), _wpCount(0), _vertexCount(0), DataModel(directory) {}
+GraphModel::GraphModel(string &directory) : _dataDirectory(directory), _wpCount(0), _vertexCount(0), DataModel(directory) {}
 
 /* ========== PUBLIC MUTATORS ========== */
 /**
@@ -136,9 +136,9 @@ unordered_set<int> GraphModel::search(const CoordGeodetic &position, const doubl
  * @param refWaypoint the required value that must be returned for the test to pass
  * @return a boolean value indicating if the test passes
  */
-bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const double &wpSepThresh, const CoordGeodetic &pos, const Vertex &refWaypoint)
+bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const CoordGeodetic &pos, const Vertex &refWaypoint)
 {
-	GraphModel graph(dataDirectory, wpSepThresh);
+	GraphModel graph(dataDirectory);
 	auto wpIndex = graph._findNearestWaypoint(pos, true);
 	auto waypoint = graph._vertices[wpIndex];
 
@@ -154,9 +154,9 @@ bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const double &wp
  * @param refWaypoint the waypoint that should be returned
  * @return a boolean value indicating if the test passes
  */
-bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const double &wpSepThresh, const CoordGeodetic &pos, const vector<CoordGeodetic> &waypoints, const Vertex &refWaypoint)
+bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const CoordGeodetic &pos, const vector<CoordGeodetic> &waypoints, const Vertex &refWaypoint)
 {
-	GraphModel graph(dataDirectory, wpSepThresh);
+	GraphModel graph(dataDirectory);
 
 	// Insert the waypoints into the graph
 	for (const auto &wpPos : waypoints)
@@ -179,10 +179,10 @@ bool GraphModel::testFindClosestWaypoint(string &dataDirectory, const double &wp
  * @param refVertex a reference to a Vertex object used to test if the pass succeeded
  * @return a boolean value indicating if the test passes
  */
-bool GraphModel::testInsert(string &dataDirectory, const double &wpSepThresh, const Tle &tle, const Vertex &refVertex)
+bool GraphModel::testInsert(string &dataDirectory, const Tle &tle, const Vertex &refVertex)
 {
 	// Create an instance of the GraphModel class
-	GraphModel graph(dataDirectory, wpSepThresh);
+	GraphModel graph(dataDirectory);
 
 	// Insert an observation
 	graph.insert(tle);
@@ -216,10 +216,10 @@ bool GraphModel::testFilterEdges(const vector<Edge> &edges, const double &maxWei
  * @param radius the range of positions from the position that are valid
  * @return an unordered set containing the NORAD category numbers within range of the position
  */
-unordered_set<int> GraphModel::testSearch(string &dataDirectory, const double &wpSepThresh, const vector<Tle> &observations, const CoordGeodetic &pos, const double &radius)
+unordered_set<int> GraphModel::testSearch(string &dataDirectory, const vector<Tle> &observations, const CoordGeodetic &pos, const double &radius)
 {
 	// Create an instance of the GraphModel class
-	GraphModel graph(dataDirectory, wpSepThresh);
+	GraphModel graph(dataDirectory);
 
 	// For each observation in observations, insert it into the graph
 	for (const auto &tle : observations)
@@ -237,10 +237,10 @@ unordered_set<int> GraphModel::testSearch(string &dataDirectory, const double &w
  * @param dataDirectory the path to the data source for the GraphModel
  * @param wpSepThresh the threshold that causes a new waypoint to be generated
  */
-void GraphModel::testImport(string &dataDirectory, const double &wpSepThresh)
+void GraphModel::testImport(string &dataDirectory)
 {
 	// Create an instance of the GraphModel class
-	GraphModel graph(dataDirectory, wpSepThresh);
+	GraphModel graph(dataDirectory);
 
 	// Perform the import process
 	graph.import();

--- a/src/GraphModel.h
+++ b/src/GraphModel.h
@@ -29,7 +29,7 @@ public:
 	};
 
 	/* ========== CONSTRUCTORS/DESTRUCTORS ========== */
-	GraphModel(string &directory, const double &sepThresh);
+	GraphModel(string &directory);
 
 	/* ========== PUBLIC MUTATORS ========== */
 	void import() override;
@@ -39,12 +39,12 @@ public:
 	unordered_set<int> search(const CoordGeodetic &position, const double &radius) override; // Returns a vector of the satellite catalog numbers
 
 	/* ========== PUBLIC TEST METHODS ========== */
-	static bool testFindClosestWaypoint(string &dataDirectory, const double &wpSepThresh, const CoordGeodetic &pos, const Vertex &refWaypoint);
-	static bool testFindClosestWaypoint(string &dataDirectory, const double &wpSepThresh, const CoordGeodetic &pos, const vector<CoordGeodetic> &waypoints, const Vertex &refWaypoint);
-	static bool testInsert(string &dataDirectory, const double &wpSepThresh, const Tle &tle, const Vertex &refVertex);
+	static bool testFindClosestWaypoint(string &dataDirectory, const CoordGeodetic &pos, const Vertex &refWaypoint);
+	static bool testFindClosestWaypoint(string &dataDirectory, const CoordGeodetic &pos, const vector<CoordGeodetic> &waypoints, const Vertex &refWaypoint);
+	static bool testInsert(string &dataDirectory, const Tle &tle, const Vertex &refVertex);
 	static bool testFilterEdges(const vector<Edge> &edges, const double &maxWeight, const vector<Edge> &refEdges);
-	static unordered_set<int> testSearch(string &dataDirectory, const double &wpSepThresh, const vector<Tle> &observations, const CoordGeodetic &pos, const double &radius);
-	static void testImport(string &dataDirectory, const double &wpSepThresh);
+	static unordered_set<int> testSearch(string &dataDirectory, const vector<Tle> &observations, const CoordGeodetic &pos, const double &radius);
+	static void testImport(string &dataDirectory);
 
 private:
 	/* ========== PRIVATE MEMBER VARIABLES ========== */
@@ -58,7 +58,7 @@ private:
 
 	map<int, vector<Edge>> _wpAdjList;
 	unordered_set<int> _waypoints;
-	double _wpSeparation;
+	double _wpSeparation = 2000; // units: kilometers
 	int _wpCount;
 
 	/* ========== PRIVATE INSERTION METHODS ========== */

--- a/tests/Graph-tests.cpp
+++ b/tests/Graph-tests.cpp
@@ -9,18 +9,16 @@ using namespace libsgp4;
 
 TEST_CASE("Check for a waypoint for a new graph", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 
 	CoordGeodetic position(0.0, 0.0, 0.0, false);
 	GraphModel::Vertex refVertex = { 0, true, position };
 
-	REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, wpSepThreshDeg, position, refVertex));
+	REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, position, refVertex));
 }
 
 TEST_CASE("Check for a waypoint when one already exists", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 
 	vector<CoordGeodetic> positions = {
@@ -34,13 +32,12 @@ TEST_CASE("Check for a waypoint when one already exists", "[GraphModel][Waypoint
 
 	for (int i = 0; i < positions.size(); i++)
 	{
-		REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, wpSepThreshDeg, positions[i], refVertices[i]));
+		REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, positions[i], refVertices[i]));
 	}
 }
 
 TEST_CASE("Get the waypoint nearest to a position", "[GraphModel][Waypoint][Search]")
 {
-	double wpSepThreshDeg = 2000; // kilometers
 	string dataDirectory = "../data";
 	vector<CoordGeodetic> wpPositions = {
 			{ 0, 0, 0, true },
@@ -57,7 +54,7 @@ TEST_CASE("Get the waypoint nearest to a position", "[GraphModel][Waypoint][Sear
 	};
 
 	// Test the waypoints to add them to the graph
-	REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, wpSepThreshDeg, refPosition, wpPositions, refWaypoint));
+	REQUIRE(GraphModel::testFindClosestWaypoint(dataDirectory, refPosition, wpPositions, refWaypoint));
 }
 
 TEST_CASE("Insert an observation", "[GraphModel][Insert]")
@@ -70,10 +67,9 @@ TEST_CASE("Insert an observation", "[GraphModel][Insert]")
 
 	// Parameters for test
 	string dataDirectory = "../data";
-	double wpSepThreshDeg = 2000; // kilometers
 	const GraphModel::Vertex vertex = { 0, false, { 0.88899156265206469, -0.073645485312217928, 426.37173319160553, true }};
 
-	REQUIRE(GraphModel::testInsert(dataDirectory, wpSepThreshDeg, tle, vertex));
+	REQUIRE(GraphModel::testInsert(dataDirectory, tle, vertex));
 }
 
 TEST_CASE("Filter edges by weight", "[GraphModel][Search]")
@@ -107,7 +103,6 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 	// Parameters for test
 	string dataDirectory = "../data";
 	string pathToTestFile = "../data/test_files/test_01.tle";
-	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 0, 158.925, 561.694, false };
 	double radius = 10; // units: km
 	unordered_set<int> refCatNums = { 12 };
@@ -134,7 +129,7 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 			}
 		}
 
-		auto catNums = GraphModel::testSearch(dataDirectory, wpSepThreshDeg, tleObjs, pos, radius);
+		auto catNums = GraphModel::testSearch(dataDirectory, tleObjs, pos, radius);
 
 		// Print out the category numbers for debugging
 		for (const auto &catNum : catNums)
@@ -155,7 +150,6 @@ TEST_CASE("Search for observations relative to position and within a range for 5
 	// Parameters for test
 	string dataDirectory = "../data";
 	string pathToTestFile = "../data/test_files/test_02.tle";
-	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 0, 153, 0, false };
 	double radius = 700; // units: km
 	unordered_set<int> refCatNums = { 12, 29, 51, 85, 115 };
@@ -182,7 +176,7 @@ TEST_CASE("Search for observations relative to position and within a range for 5
 			}
 		}
 
-		auto catNums = GraphModel::testSearch(dataDirectory, wpSepThreshDeg, tleObjs, pos, radius);
+		auto catNums = GraphModel::testSearch(dataDirectory, tleObjs, pos, radius);
 
 		// Print out the category numbers for debugging
 		for (const auto &catNum : catNums)
@@ -203,7 +197,6 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 	// Parameters for test
 	string dataDirectory = "../data";
 	string pathToTestFile = "../data/test_files/test_03.tle";
-	double wpSepThreshDeg = 2000; // kilometers
 	CoordGeodetic pos = { 29.649294, -82.339383, 0, false }; // Lat, Long of Tigert hall
 	double radius = 1000; // units: km
 	unordered_set<int> refCatNums = { 340, 414, 549, 745, 561, 446, 657, 268, 406, 544, 659, 648, 672, 660, 405, 704, 224, 753 };
@@ -230,7 +223,7 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 			}
 		}
 
-		auto catNums = GraphModel::testSearch(dataDirectory, wpSepThreshDeg, tleObjs, pos, radius);
+		auto catNums = GraphModel::testSearch(dataDirectory, tleObjs, pos, radius);
 
 		// Print out the category numbers for debugging
 		for (const auto &catNum : catNums)
@@ -248,8 +241,7 @@ TEST_CASE("Search for observations relative to position and within a range for 1
 TEST_CASE("Import all the TLE data in the data directory", "[GraphModel][Import]")
 {
 	string dataDirectory = "../data";
-	double wpSepThreshDeg = 2000; // kilometers
 
 	// Perform the import
-	REQUIRE_NOTHROW(GraphModel::testImport(dataDirectory, wpSepThreshDeg));
+	REQUIRE_NOTHROW(GraphModel::testImport(dataDirectory));
 }


### PR DESCRIPTION
After testing, it was determined that a threshold of 2000 kilometers is ideal and we don't want to expose this as a configurable option for users